### PR TITLE
py-torch@1.4.1: auto-include std headers for fbgemm; disable MKLDNN f…

### DIFF
--- a/packages/py-protobuf/package.py
+++ b/packages/py-protobuf/package.py
@@ -77,6 +77,17 @@ class PyProtobuf(PythonPackage):
 
     conflicts("+cpp", when="^python@3.11:")
 
+    def patch(self):
+        # Older releases used distutils' 2to3 support which has been removed
+        # from modern setuptools. Replace build_py_2to3 with build_py.
+        if self.spec.satisfies("@:3.6.1"):
+            filter_file(
+                "from distutils.command.build_py import build_py_2to3 as _build_py",
+                "from distutils.command.build_py import build_py as _build_py",
+                "setup.py",
+                string=True,
+            )
+
     @property
     def build_directory(self):
         if self.spec.satisfies("@3.1.0"):


### PR DESCRIPTION
…or 1.4.x to avoid oneDNN symbol issues.\npy-protobuf@3.6.1: replace build_py_2to3 with build_py for modern setuptools.\nValidated by building & importing torch.