### PR TITLE
r-seuratwrappers: require Seurat >=5 for 2023-04-18+; fixes install f…

### DIFF
--- a/packages/r-seuratwrappers/package.py
+++ b/packages/r-seuratwrappers/package.py
@@ -22,8 +22,7 @@ class RSeuratwrappers(RPackage):
 	depends_on("r-matrix", type=("build", "run"))
 	depends_on("r-remotes", type=("build", "run"))
 	depends_on("r-rsvd", type=("build", "run"))
-	# Allow compatibility with environments pinning Seurat 4.1.x
-	depends_on("r-seurat@4.1.0:", type=("build", "run"), when="@2023-04-18:")
-	depends_on("r-seurat@5.0.0:", type=("build", "run"), when="@2024-01-29:")
+	# SeuratWrappers requires Seurat >= 5 for current snapshots
+	depends_on("r-seurat@5:", type=("build", "run"), when="@2023-04-18:")
 	depends_on("r-rlang", type=("build", "run"))
 	depends_on("r-r-utils", type=("build", "run"))


### PR DESCRIPTION
…ailure against Seurat 4.x. Verified by installing and loading SeuratWrappers with Seurat 5.