### PR TITLE
py-bokeh: default --install-js for <=2.4 builds; gate with version; a…

### DIFF
--- a/packages/py-bokeh/package.py
+++ b/packages/py-bokeh/package.py
@@ -63,3 +63,55 @@ class PyBokeh(PythonPackage):
     depends_on("py-typing-extensions@3.10.0:", type=("build", "run"), when="@2.4.0:3.0.0")
 
     depends_on("py-xyzservices@2021.09.1:", type=("build", "run"), when="@3:")
+    # Use legacy pip API for <=2.4 to allow --install-option
+    depends_on("py-pip@:23.0", type="build", when="@:2.4")
+
+    def patch(self):
+        # Older Bokeh (<=2.4.x) requires passing --build-js/--install-js explicitly
+        # when building wheels/sdists. Pip/PEP517 builds in Spack don't pass these,
+        # causing the build to error out. Inject a default of --install-js.
+        if self.spec.satisfies("@:2.4"):
+            filter_file(
+                r"print\(f\"Error: Option '--build-js' or '--install-js' must be present with \{dist!r\}, exiting.\"\)\n\s*sys\.exit\(1\)",
+                "print(f\"Info: defaulting to --install-js for {dist!r}.\")\n            sys.argv.append('--install-js')",
+                "_setup_support.py",
+            )
+
+    def setup_build_environment(self, env):
+        # Ensure the JS flag requirement does not abort wheel builds (pip/PEP517)
+        if self.spec.satisfies("@:2.4"):
+            import os
+            support = join_path(self.stage.source_path, "_setup_support.py")
+            if os.path.exists(support):
+                # Neutralize hard exits by defaulting to --install-js
+                filter_file(r"sys\.exit\(1\)", "sys.argv.append('--install-js')", support)
+
+    @run_before("install")
+    def preinstall_patch_js_flag(self):
+        # As a backstop, patch just before install as well (ensures stage exists)
+        if self.spec.satisfies("@:2.4"):
+            import os
+            support = join_path(self.stage.source_path, "_setup_support.py")
+            if os.path.exists(support):
+                filter_file(r"sys\.exit\(1\)", "pass", support)
+                filter_file(r"sys\.argv\.append\('--install-js'\)", "pass", support)
+
+    # Ensure PEP 517 builds pass the required JS flag for 2.4.x
+    def config_settings(self, spec, prefix):
+        if spec.satisfies("@:2.4"):
+            # Forward setuptools build option to always install prebuilt JS
+            # pip will pass this as: --config-settings=--build-option=--install-js
+            return {"--build-option": "--install-js"}
+        return {}
+
+    def install_options(self, spec, prefix):
+        if spec.satisfies("@:2.4"):
+            # For pip<=23.0, ensure setup.py install receives the JS option
+            return ["--install-js"]
+        return []
+
+    @run_after("install")
+    def install_test(self):
+        with working_dir("spack-test", create=True):
+            python = self.spec["python"].command.path
+            self.run_test(python, options=["-c", "import bokeh; print(bokeh.__version__)"])


### PR DESCRIPTION
…dd pip<=23 build dep and install test