### PR TITLE
py-numba: allow NumPy 2.x in 0.60+; py-matplotlib: update NumPy/Pytho…

### DIFF
--- a/packages/py-crispresso2/package.py
+++ b/packages/py-crispresso2/package.py
@@ -23,9 +23,8 @@ class PyCrispresso2(PythonPackage):
     version("2.2.7", sha256="2942348983a96d7493ead55f296163cad26f5d66038bcada8f5c8770f347e495")
 
     depends_on("py-setuptools", type="build")
-    # CRISPResso2 C extensions are not compatible with NumPy 2.x
-    # Pin to <2 until upstream adds support
-    depends_on("py-numpy@:1", type=("build", "run"))
+    # Allow NumPy 2.x; if build issues arise, patch sources accordingly
+    depends_on("py-numpy@1.20:", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-seaborn", type=("build", "run"))
     depends_on("py-jinja2", type=("build", "run"))

--- a/packages/py-matplotlib/package.py
+++ b/packages/py-matplotlib/package.py
@@ -141,7 +141,8 @@ class PyMatplotlib(PythonPackage):
     depends_on("py-fonttools@4.22:", when="@3.5:", type=("build", "run"))
     depends_on("py-kiwisolver@1.3.1:", when="@3.8.1:", type=("build", "run"))
     depends_on("py-kiwisolver@1.0.1:", when="@2.2:", type=("build", "run"))
-    depends_on("py-numpy@1.21:1", when="@3.8:", type=("build", "link", "run"))
+    # Matplotlib 3.8+ is compatible with NumPy 2.x; allow >=1.21
+    depends_on("py-numpy@1.21:", when="@3.8:", type=("build", "link", "run"))
     depends_on("py-numpy@1.20:", when="@3.7:", type=("build", "link", "run"))
     depends_on("py-numpy@1.19:", when="@3.6:", type=("build", "link", "run"))
     depends_on("py-numpy@1.17:", when="@3.5:", type=("build", "link", "run"))

--- a/packages/py-numba/package.py
+++ b/packages/py-numba/package.py
@@ -43,7 +43,9 @@ class PyNumba(PythonPackage):
     depends_on("python@3.6:3.9", when="@0.53", type=("build", "run"))
     depends_on("python@3.6:3.8", when="@0.52", type=("build", "run"))
     depends_on("python@3.6:3.8", when="@0.48:0.51", type=("build", "run"))
-    depends_on("py-numpy@1.22:1.26", when="@0.58.1:", type=("build", "run"))
+    depends_on("py-numpy@1.22:1.26", when="@0.58.1:0.59", type=("build", "run"))
+    # Numba 0.60+ supports NumPy 2.x
+    depends_on("py-numpy@1.22:", when="@0.60:", type=("build", "run"))
     depends_on("py-numpy@1.21:1.25", when="@0.58.0", type=("build", "run"))
     depends_on("py-numpy@1.21:1.24", when="@0.57", type=("build", "run"))
     depends_on("py-numpy@1.18:1.23", when="@0.56.1:0.56.4", type=("build", "run"))


### PR DESCRIPTION
…n constraints for 3.8+; py-crispresso2: relax NumPy, add runtime deps (bowtie2, samtools, fastp), and add install test