### PR TITLE
Fix multiome-analysisr recipes

### DIFF
--- a/packages/r-archr/package.py
+++ b/packages/r-archr/package.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import inspect
+import os
+import tarfile
+
 from spack.package import *
 
 
@@ -15,7 +19,7 @@ class RArchr(RPackage):
 
     maintainers("dorton21")
 
-    version("1.0.3", sha256="9e3c5f07b599ff806c6f2a74ec619b0847e69cb3e96dc29fa1304f2a381620e4")
+    version("1.0.3", sha256="9e3c5f07b599ff806c6f2a74ec619b0847e69cb3e96dc29fa1304f2a381620e4", expand=False)
 
     depends_on("r@4.0.0:", type=("build", "run"))
 
@@ -59,3 +63,41 @@ class RArchr(RPackage):
         depends_on("r-cairo")
         depends_on("r-ggrastr")
         depends_on("r-rhandsontable")
+
+    def install(self, spec, prefix):
+        archive = self.stage.archive_file
+        source_root = join_path(self.stage.path, "manual-source")
+        mkdirp(source_root)
+
+        with tarfile.open(archive, "r:gz") as tar:
+            tar.extractall(source_root)
+
+        entries = os.listdir(source_root)
+        if len(entries) != 1:
+            raise InstallError("Expected a single top-level ArchR source directory")
+
+        source_path = join_path(source_root, entries[0])
+        compact_r_libs = join_path(self.stage.path, "compact-r-libs")
+        mkdirp(compact_r_libs)
+        for dep in spec.traverse(root=False):
+            if not dep.name.startswith("r-"):
+                continue
+            dep_lib_root = join_path(dep.prefix, "rlib", "R", "library")
+            if not os.path.isdir(dep_lib_root):
+                continue
+            for entry in os.listdir(dep_lib_root):
+                src = join_path(dep_lib_root, entry)
+                dst = join_path(compact_r_libs, entry)
+                if not os.path.exists(dst):
+                    os.symlink(src, dst)
+
+        args = ["--vanilla", "CMD", "INSTALL", "--library={0}".format(self.module.r_lib_dir), source_path]
+        original_r_libs = os.environ.get("R_LIBS")
+        os.environ["R_LIBS"] = "{0}:{1}".format(compact_r_libs, self.module.r_lib_dir)
+        try:
+            inspect.getmodule(self).R(*args)
+        finally:
+            if original_r_libs is None:
+                os.environ.pop("R_LIBS", None)
+            else:
+                os.environ["R_LIBS"] = original_r_libs

--- a/packages/r-azimuth/package.py
+++ b/packages/r-azimuth/package.py
@@ -45,3 +45,52 @@ class RAzimuth(RPackage):
     depends_on("r-jaspar2020", type=('build', 'run'))
     depends_on("r-tfbstools", type=('build', 'run'))
     depends_on("r-signac", type=('build', 'run'))
+
+    def patch(self):
+        if not self.spec.satisfies("@0.5.0"):
+            return
+
+        filter_file(
+            "importFrom(Signac,CreateChromatinAssay)",
+            "importFrom(Signac,CreateChromatinAssay5)",
+            "NAMESPACE",
+            string=True,
+        )
+        filter_file(
+            "importFrom(Signac,GRangesToString)\n",
+            "",
+            "NAMESPACE",
+            string=True,
+        )
+        filter_file("CreateChromatinAssay(", "CreateChromatinAssay5(", "R/azimuth.R", string=True)
+        filter_file("CreateChromatinAssay(", "CreateChromatinAssay5(", "R/server.R", string=True)
+        filter_file(
+            'inherits(x = query[[assay]], what = "ChromatinAssay")',
+            'inherits(x = query[[assay]], what = c("ChromatinAssay", "ChromatinAssay5"))',
+            "R/azimuth.R",
+            string=True,
+        )
+        filter_file(
+            'inherits(x = atac, what = "ChromatinAssay")',
+            'inherits(x = atac, what = c("ChromatinAssay", "ChromatinAssay5"))',
+            "R/helpers.R",
+            string=True,
+        )
+        filter_file(
+            '!inherits(x = object[[assay]], what = "ChromatinAssay")',
+            '!inherits(x = object[[assay]], what = c("ChromatinAssay", "ChromatinAssay5"))',
+            "R/helpers.R",
+            string=True,
+        )
+        filter_file(
+            "GRangesToString(subject[subjectHits(o_hits)])",
+            "as.character(subject[subjectHits(o_hits)])",
+            "R/helpers.R",
+            string=True,
+        )
+        filter_file(
+            "GRangesToString(grange = subject)",
+            "as.character(subject)",
+            "R/helpers.R",
+            string=True,
+        )

--- a/packages/r-cner/package.py
+++ b/packages/r-cner/package.py
@@ -33,6 +33,7 @@ class RCner(RPackage):
 	depends_on("r-genomeinfodb@1.1.3:", type=("build", "run"))
 	depends_on("r-genomicranges@1.23.16:", type=("build", "run"))
 	depends_on("r-rtracklayer@1.25.5:", type=("build", "run"))
+	depends_on("r-seqinfo", type=("build", "run"))
 	depends_on("r-xvector", type=("build", "run"))
 	depends_on("r-genomicalignments@1.1.9:", type=("build", "run"))
 	depends_on("r-s4vectors", type=("build", "run"))
@@ -47,3 +48,32 @@ class RCner(RPackage):
 	depends_on("r-r-utils@2.3:", type=("build", "run"))
 	depends_on("r-keggrest@1.14:", type=("build", "run"))
 	depends_on("zlib", type=("build", "link", "run"))
+
+	def patch(self):
+		if not self.spec.satisfies("@1.38.0"):
+			return
+
+		filter_file(
+			"        GenomeInfoDb (>= 1.1.3), GenomicRanges (>= 1.23.16),",
+			"        GenomeInfoDb (>= 1.1.3), GenomicRanges (>= 1.23.16), Seqinfo,",
+			"DESCRIPTION",
+			string=True,
+		)
+		filter_file(
+			"importMethodsFrom(GenomeInfoDb,",
+			"importMethodsFrom(Seqinfo,",
+			"NAMESPACE",
+			string=True,
+		)
+		filter_file(
+			"importFrom(GenomeInfoDb, Seqinfo)",
+			"importFrom(Seqinfo, Seqinfo)",
+			"NAMESPACE",
+			string=True,
+		)
+		filter_file(
+			"importMethodsFrom(Biostrings, compareStrings)",
+			"importFrom(Biostrings, compareStrings)",
+			"NAMESPACE",
+			string=True,
+		)

--- a/packages/r-epiregulon-archr/package.py
+++ b/packages/r-epiregulon-archr/package.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import inspect
+import os
+import tarfile
+
 from spack.package import *
 
 
@@ -17,11 +21,16 @@ class REpiregulonArchr(RPackage):
     gene regulatory networks and infer transcription factor activity in single cells."""
 
     homepage = "https://github.com/xiaosaiyao/epiregulon.archr/"
-    git = "https://github.com/xiaosaiyao/epiregulon.archr.git"
+    url = "https://github.com/xiaosaiyao/epiregulon.archr/archive/refs/heads/master.tar.gz"
 
     license("MIT")
 
-    version("0.99.5", commit="a02bd18b69944393031e77bb822a29f9afc806a0")
+    version("0.99.5", sha256="f640df2a2c76fd928c91dbfb46b47c1b94adb9384e06e7855961c4d807e1a440", expand=False)
+
+    def url_for_version(self, version):
+        if str(version) == "0.99.5":
+            return "https://github.com/xiaosaiyao/epiregulon.archr/archive/a02bd18b69944393031e77bb822a29f9afc806a0.tar.gz"
+        return super().url_for_version(version)
 
     # Depends
     depends_on("r@4.4:", type=("build", "run"))
@@ -34,9 +43,15 @@ class REpiregulonArchr(RPackage):
     depends_on("r-checkmate", type=("build", "run"))
     depends_on("r-archr", type=("build", "run"))
     depends_on("r-biocgenerics", type=("build", "run"))
+    depends_on("r-bluster", type=("build", "run"))
+    depends_on("r-genomeinfodb", type=("build", "run"))
     depends_on("r-s4vectors", type=("build", "run"))
     depends_on("r-iranges", type=("build", "run"))
     depends_on("r-genomicranges", type=("build", "run"))
+    depends_on("r-multiassayexperiment", type=("build", "run"))
+    depends_on("r-rhdf5", type=("build", "run"))
+    depends_on("r-scran", type=("build", "run"))
+    depends_on("r-scmultiome", type=("build", "run"))
     depends_on("r-ggplot2", type=("build", "run"))
 
     # Suggests
@@ -45,4 +60,41 @@ class REpiregulonArchr(RPackage):
     depends_on("r-biocstyle", type=("build"))
     depends_on("r-testthat", type=("build"))
     depends_on("r-epiregulon-extra", type=("build"))
-    depends_on("r-scmultiome", type=("build"))
+
+    def install(self, spec, prefix):
+        archive = self.stage.archive_file
+        source_root = join_path(self.stage.path, "manual-source")
+        mkdirp(source_root)
+
+        with tarfile.open(archive, "r:gz") as tar:
+            tar.extractall(source_root)
+
+        entries = os.listdir(source_root)
+        if len(entries) != 1:
+            raise InstallError("Expected a single top-level epiregulon.archr source directory")
+
+        source_path = join_path(source_root, entries[0])
+        compact_r_libs = join_path(self.stage.path, "compact-r-libs")
+        mkdirp(compact_r_libs)
+        for dep in spec.traverse(root=False):
+            if not dep.name.startswith("r-"):
+                continue
+            dep_lib_root = join_path(dep.prefix, "rlib", "R", "library")
+            if not os.path.isdir(dep_lib_root):
+                continue
+            for entry in os.listdir(dep_lib_root):
+                src = join_path(dep_lib_root, entry)
+                dst = join_path(compact_r_libs, entry)
+                if not os.path.exists(dst):
+                    os.symlink(src, dst)
+
+        args = ["--vanilla", "CMD", "INSTALL", "--library={0}".format(self.module.r_lib_dir), source_path]
+        original_r_libs = os.environ.get("R_LIBS")
+        os.environ["R_LIBS"] = "{0}:{1}".format(compact_r_libs, self.module.r_lib_dir)
+        try:
+            inspect.getmodule(self).R(*args)
+        finally:
+            if original_r_libs is None:
+                os.environ.pop("R_LIBS", None)
+            else:
+                os.environ["R_LIBS"] = original_r_libs

--- a/packages/r-epiregulon-extra/package.py
+++ b/packages/r-epiregulon-extra/package.py
@@ -20,6 +20,10 @@
 # See the Spack documentation for more information on packaging.
 # ----------------------------------------------------------------------------
 
+import inspect
+import os
+import tarfile
+
 from spack.package import *
 
 
@@ -36,14 +40,14 @@ class REpiregulonExtra(RPackage):
 
     homepage = "https://github.com/xiaosaiyao/epiregulon.extra/"
     urls = [
-        "https://www.bioconductor.org/packages/release/bioc/src/contrib/epiregulon.extra_1.2.1.tar.gz",
-        "https://www.bioconductor.org/packages/3.20/bioc/src/contrib/Archive/epiregulon.extra/epiregulon.extra_1.2.1.tar.gz",
+        "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.21/bioc/src/contrib/epiregulon.extra_1.4.0.tar.gz",
+        "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.20/bioc/src/contrib/Archive/epiregulon.extra/epiregulon.extra_1.2.1.tar.gz",
     ]
     bioc = "epiregulon.extra"
 
     license("MIT")
 
-    version("1.4.0", tag="RELEASE_3_21")
+    version("1.4.0", sha256="6cacb9854584df916c98cf7ba459833228748126ec70d4cbd276c23db90aac22", expand=False)
     version("1.2.2", commit="aa85b232399d3cb21b06887f999adc52ad6d1e87")
 
     # Depends
@@ -82,3 +86,41 @@ class REpiregulonExtra(RPackage):
     depends_on("r-vdiffr", type=("build"))
     depends_on("r-ggrastr", type=("build"))
     depends_on("r-ggrepel", type=("build"))
+
+    def install(self, spec, prefix):
+        archive = self.stage.archive_file
+        source_root = join_path(self.stage.path, "manual-source")
+        mkdirp(source_root)
+
+        with tarfile.open(archive, "r:gz") as tar:
+            tar.extractall(source_root)
+
+        entries = os.listdir(source_root)
+        if len(entries) != 1:
+            raise InstallError("Expected a single top-level epiregulon.extra source directory")
+
+        source_path = join_path(source_root, entries[0])
+        compact_r_libs = join_path(self.stage.path, "compact-r-libs")
+        mkdirp(compact_r_libs)
+        for dep in spec.traverse(root=False):
+            if not dep.name.startswith("r-"):
+                continue
+            dep_lib_root = join_path(dep.prefix, "rlib", "R", "library")
+            if not os.path.isdir(dep_lib_root):
+                continue
+            for entry in os.listdir(dep_lib_root):
+                src = join_path(dep_lib_root, entry)
+                dst = join_path(compact_r_libs, entry)
+                if not os.path.exists(dst):
+                    os.symlink(src, dst)
+
+        args = ["--vanilla", "CMD", "INSTALL", "--library={0}".format(self.module.r_lib_dir), source_path]
+        original_r_libs = os.environ.get("R_LIBS")
+        os.environ["R_LIBS"] = "{0}:{1}".format(compact_r_libs, self.module.r_lib_dir)
+        try:
+            inspect.getmodule(self).R(*args)
+        finally:
+            if original_r_libs is None:
+                os.environ.pop("R_LIBS", None)
+            else:
+                os.environ["R_LIBS"] = original_r_libs

--- a/packages/r-tfbstools/package.py
+++ b/packages/r-tfbstools/package.py
@@ -44,11 +44,60 @@ class RTfbstools(RPackage):
 	depends_on("r-genomicranges@1.20.6:", type=("build", "run"))
 	depends_on("r-gtools@3.5:", type=("build", "run"))
 	depends_on("r-iranges@2.2.7:", type=("build", "run"))
+	depends_on("r-seqinfo", type=("build", "run"), when="@1.40.0:")
 	depends_on("r-dbi@0.6:", type=("build", "run"))
 	depends_on("r-rsqlite@1:", type=("build", "run"))
 	depends_on("r-rtracklayer@1.28.10:", type=("build", "run"))
 	depends_on("r-seqlogo@1.34:", type=("build", "run"), when="@1.8.3:")
 	depends_on("r-s4vectors@0.9.25:", type=("build", "run"))
 	depends_on("r-tfmpvalue@0.0.5:", type=("build", "run"))
+	depends_on("r-pwalign", type=("build", "run"), when="@1.40.0:")
 	depends_on("r-xml@3.98.1.3:", type=("build", "run"))
 	depends_on("r-xvector@0.8:", type=("build", "run"))
+
+	def patch(self):
+		if not self.spec.satisfies("@1.40.0"):
+			return
+
+		filter_file(
+			"Imports: Biobase(>= 2.28), Biostrings(>= 2.36.4), BiocGenerics(>=",
+			"Imports: Biobase(>= 2.28), Biostrings(>= 2.36.4), pwalign, BiocGenerics(>=",
+			"DESCRIPTION",
+			string=True,
+		)
+		filter_file(
+			"        1.10.0), GenomeInfoDb(>= 1.6.1), GenomicRanges(>= 1.20.6),",
+			"        1.10.0), GenomeInfoDb(>= 1.6.1), Seqinfo, GenomicRanges(>= 1.20.6),",
+			"DESCRIPTION",
+			string=True,
+		)
+		filter_file(
+			"importClassesFrom(Biostrings, DNAStringSet, PairwiseAlignments, XStringViews)",
+			"importClassesFrom(Biostrings, DNAStringSet, XStringViews)\nimportClassesFrom(pwalign, PairwiseAlignments)",
+			"NAMESPACE",
+			string=True,
+		)
+		filter_file(
+			"consensusMatrix, PairwiseAlignments, pattern, consensusMatrix",
+			"consensusMatrix, consensusMatrix",
+			"NAMESPACE",
+			string=True,
+		)
+		filter_file(
+			'importMethodsFrom(Biostrings, reverseComplement, matchPWM, maxScore, minScore, \n                  consensusMatrix, consensusMatrix)',
+			'importMethodsFrom(Biostrings, reverseComplement, matchPWM, maxScore, minScore, \n                  consensusMatrix, consensusMatrix)',
+			"NAMESPACE",
+			string=True,
+		)
+		filter_file(
+			"importMethodsFrom(GenomeInfoDb, seqinfo)",
+			"importMethodsFrom(Seqinfo, seqinfo)",
+			"NAMESPACE",
+			string=True,
+		)
+		filter_file(
+			"importFrom(seqLogo, seqLogo, makePWM)",
+			"importFrom(seqLogo, seqLogo, makePWM)\nimportFrom(pwalign, pattern, PairwiseAlignments)",
+			"NAMESPACE",
+			string=True,
+		)


### PR DESCRIPTION
## Summary
- update the six affected R recipes needed for the multiome-analysisr stack
- ensure the changed package names are installed so the repository hook validates cleanly

## Test plan
- ./githooks/spack-validate-changed-packages.sh packages/r-archr/package.py packages/r-azimuth/package.py packages/r-cner/package.py packages/r-epiregulon-archr/package.py packages/r-epiregulon-extra/package.py packages/r-tfbstools/package.py

Made with [Cursor](https://cursor.com)