### PR TITLE
Disable pdf variant in groff

### DIFF
--- a/packages/cyrus-sasl/package.py
+++ b/packages/cyrus-sasl/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class CyrusSasl(AutotoolsPackage):
+    """This is the Cyrus SASL API implementation. It can be used on the
+    client or server side to provide authentication and authorization
+    services."""
+
+    homepage = "https://github.com/cyrusimap/cyrus-sasl"
+    url = "https://github.com/cyrusimap/cyrus-sasl/archive/cyrus-sasl-2.1.27.tar.gz"
+
+    version("2.1.28", sha256="3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341")
+    version("2.1.27", sha256="b564d773803dc4cff42d2bdc04c80f2b105897a724c247817d4e4a99dd6b9976")
+    version("2.1.26", sha256="7c14d1b5bd1434adf2dd79f70538617e6aa2a7bde447454b90b84ac5c4d034ba")
+    version("2.1.25", sha256="8bfd4fa4def54c760e5061f2a74c278384c3b9807f02c4b07dab68b5894cc7c1")
+    version("2.1.24", sha256="1df15c492f7ecb90be49531a347b3df21b041c2e0325dcc4fc5a6e98384c40dd")
+    version("2.1.23", sha256="b1ec43f62d68446a6a5879925c63d94e26089c5a46cd83e061dd685d014c7d1f")
+
+    depends_on("m4", type="build")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("groff", type="build")

--- a/packages/groff/BuildFoundries.patch
+++ b/packages/groff/BuildFoundries.patch
@@ -1,0 +1,11 @@
+--- a/font/devpdf/Makefile.sub  2014-11-04 02:38:35.427521472 -0600
++++ b/font/devpdf/Makefile.sub  2021-02-08 14:28:51.194111775 -0600
+@@ -95,7 +95,7 @@
+        chmod +x util/BuildFoundries
+        echo "# foundry ps name psfile" > $(top_builddir)/font/devpdf/download
+        PATH="$(top_builddir)/src/utils/afmtodit:$(GROFF_PATH_SEPARATOR)$(PATH)" \
+-         util/BuildFoundries $(top_builddir)/font/devpdf \
++         $(PERL) util/BuildFoundries $(top_builddir)/font/devpdf \
+            '$(top_srcdir)/font/devps : $(top_builddir)/font/devps' \
+           >> $(top_builddir)/font/devpdf/download
+ 

--- a/packages/groff/package.py
+++ b/packages/groff/package.py
@@ -1,0 +1,100 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
+from spack.package import *
+from spack.util.environment import is_system_path
+
+
+class Groff(AutotoolsPackage, GNUMirrorPackage):
+    """Groff (GNU troff) is a typesetting system that reads
+    plain text mixed with formatting commands and produces
+    formatted output. Output may be PostScript or PDF, html, or
+    ASCII/UTF8 for display at the terminal."""
+
+    homepage = "https://www.gnu.org/software/groff/"
+    gnu_mirror_path = "groff/groff-1.22.3.tar.gz"
+
+    tags = ["build-tools"]
+
+    version("1.22.4", sha256="e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293")
+    version("1.22.3", sha256="3a48a9d6c97750bfbd535feeb5be0111db6406ddb7bb79fc680809cda6d828a5")
+
+    # TODO: add html variant, spack doesn't have netpbm and its too
+    # complicated for me to find out at this point in time.
+    # See brew scripts for groff for guidance:
+    # https://github.com/Homebrew/homebrew-core/blob/master/Formula/groff.rb
+    # Seems troublesome...netpbm requires groff?
+
+    # Disabled pdf variant and it's dependency because it's causing openssh to never concretize
+    # variant("pdf", default=False, description="Build the `gropdf` executable.")
+    variant("x", default=False, description="Enable set of graphical options")
+    variant(
+        "uchardet",
+        default=True,
+        description="Builds preconv with uchardet library for "
+        "automatic file encoding detection",
+    )
+
+    conflicts("+uchardet", when="@:1.22.3")
+
+    depends_on("gawk", type="build")
+    depends_on("gmake", type="build")
+    depends_on("sed", type="build")
+
+
+    # depends_on("ghostscript", when="+pdf")
+    # # iconv is being asked whatever the release
+    depends_on("iconv")
+    # makeinfo is being searched for
+    depends_on("texinfo", type="build", when="@1.22.4:")
+    # configure complains when there is no uchardet that enhances preconv
+    depends_on("uchardet", when="@1.22.4:")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("libice", when="+x")
+    depends_on("libxaw", when="+x")
+    depends_on("libxmu", when="+x")
+    depends_on("libx11", when="+x")
+
+    # The perl interpreter line in scripts might be too long as it has
+    # not been transformed yet. Call scripts with spack perl explicitly.
+    patch("BuildFoundries.patch", when="@1.22.3")
+    patch("pdfmom.patch", when="@1.22.3")
+
+    executables = ["^groff$"]
+
+    @property
+    def parallel(self):
+        return False
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"GNU groff version\s+(\S+)", output)
+        return match.group(1) if match else None
+
+    def configure_args(self):
+        args = ["--disable-silent-rules"]
+        args.extend(self.with_or_without("x"))
+        if "@1.22.4:" in self.spec:
+            args.extend(self.with_or_without("uchardet"))
+        if self.spec["iconv"].name == "libc":
+            args.append("--without-libiconv-prefix")
+        elif not is_system_path(self.spec["iconv"].prefix):
+            args.append("--with-libiconv-prefix={0}".format(self.spec["iconv"].prefix))
+        return args
+
+    def setup_run_environment(self, env):
+        if self.spec.satisfies("+x"):
+            dir = join_path(self.prefix.lib, "X11", "app-defaults")
+            env.set_path("XFILESEARCHPATH", dir)
+
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%clang@16:"):
+                flags.append("-Wno-register")
+        return (flags, None, None)

--- a/packages/groff/pdfmom.patch
+++ b/packages/groff/pdfmom.patch
@@ -1,0 +1,11 @@
+--- a/contrib/mom/Makefile.sub  2014-11-04 02:38:35.502520534 -0600
++++ b/contrib/mom/Makefile.sub  2021-02-08 14:51:57.131553432 -0600
+@@ -41,7 +41,7 @@
+   GROFF_COMMAND_PREFIX= \
+   GROFF_BIN_PATH="$(GROFF_BIN_PATH)" \
+   PDFMOM_BIN_PATH="$(top_builddir)/src/devices/gropdf" \
+-  $(PDFMOMBIN) $(FFLAG) $(TFLAG) $(KFLAG)
++  $(PERL) $(PDFMOMBIN) $(FFLAG) $(TFLAG) $(KFLAG)
+ 
+ MAN7=\
+   groff_mom.n

--- a/packages/openldap/package.py
+++ b/packages/openldap/package.py
@@ -1,0 +1,109 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Openldap(AutotoolsPackage):
+    """
+    OpenLDAP Software is an open source implementation of the Lightweight
+    Directory Access Protocol. The suite includes:
+
+    slapd - stand-alone LDAP daemon (server)
+    libraries implementing the LDAP protocol, and
+    utilities, tools, and sample clients.
+    """
+
+    homepage = "https://www.openldap.org/"
+    url = "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.0.tgz"
+
+    version("2.6.4", sha256="d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991")
+    version("2.6.0", sha256="b71c580eac573e9aba15d95f33dd4dd08f2ed4f0d7fc09e08ad4be7ed1e41a4f")
+    version("2.4.49", sha256="e3b117944b4180f23befe87d0dcf47f29de775befbc469dcf4ac3dab3311e56e")
+    version("2.4.48", sha256="d9523ffcab5cd14b709fcf3cb4d04e8bc76bb8970113255f372bc74954c6074d")
+
+    variant("client_only", default=True, description="Client only installation")
+    variant("icu", default=False, description="Build with unicode support")
+    # Below, tls=none is not an option from programming point of view
+    # If +client_only, configure arguments for tls won't be enabled
+    variant(
+        "tls",
+        default="gnutls",
+        description="Build with TLS support",
+        values=("gnutls", "openssl"),
+        multi=False,
+    )
+
+    variant("perl", default=False, description="Perl backend to Slapd")
+    variant("sasl", default=True, description="Build with Cyrus SASL support")
+    variant("static", default=False, description="Build static libraries")
+    variant("shared", default=True, description="Build shared libraries")
+    variant("dynamic", default=True, description="Enable linking built binaries with dynamic libs")
+    variant("wt", default=False, description="Enable WiredTiger backend", when="@2.5.0:")
+    conflicts("~static", when="~shared")
+
+    depends_on("icu4c", when="+icu")
+    depends_on("gnutls", when="~client_only tls=gnutls")
+    depends_on("openssl", when="~client_only tls=openssl")
+    depends_on("openssl@1.1.1:", when="~client_only tls=openssl @2.6.0:")
+    depends_on("unixodbc", when="~client_only")
+    depends_on("postgresql", when="~client_only")
+    depends_on("berkeley-db", when="~client_only")  # for slapd
+    # Recommended dependencies by Linux From Scratch
+    depends_on("cyrus-sasl", when="+sasl")
+    # depends_on('openslp', when='~client_only') # not avail. in spack yet
+    # depends_on('Pth', when='~client_only') # not avail. in spack yet
+    depends_on("perl", when="~client_only+perl")  # for slapd
+    depends_on("groff", type="build")
+    depends_on("pkgconfig", type="build")
+    depends_on("wiredtiger", when="@2.6.0:")
+
+    # Ref: https://www.linuxfromscratch.org/blfs/view/svn/server/openldap.html
+    @when("+client_only")
+    def configure_args(self):
+        args = ["CPPFLAGS=-D_GNU_SOURCE", "--disable-debug", "--disable-slapd"]
+        args += self.with_or_without("cyrus-sasl", variant="sasl")
+        args += self.enable_or_disable("static")
+        args += self.enable_or_disable("shared")
+        args += self.enable_or_disable("dynamic")
+        return args
+
+    @when("~client_only")
+    def configure_args(self):
+        # Ref: https://www.openldap.org/lists/openldap-technical/201009/msg00304.html
+        args = [
+            "CPPFLAGS=-D_GNU_SOURCE",  # fixes a build error, see Ref above
+            "--disable-debug",
+            "--enable-crypt",
+            "--enable-spasswd",
+            "--enable-slapd",
+            "--enable-modules",
+            "--enable-rlookups",
+            "--enable-backends=mod",
+            "--disable-sql",
+            "--enable-overlays=mod",
+        ]
+
+        if self.spec.satisfies("@:2.5"):
+            args.extend(("--disable-ndb", "--disable-shell", "--disable-bdb", "--disable-hdb"))
+
+        args += self.enable_or_disable("static")
+        args += self.enable_or_disable("shared")
+        args += self.enable_or_disable("dynamic")
+        args += self.with_or_without("cyrus-sasl", variant="sasl")
+        args.append("--with-tls=" + self.spec.variants["tls"].value)
+        if self.spec.satisfies("@2.6.0: tls=gnutls"):
+            args += ["--disable-autoca"]
+
+        if self.spec.satisfies("@2.5.0:"):
+            args += self.enable_or_disable("wt")
+
+        args += self.enable_or_disable("perl")
+
+        return args
+
+    def build(self, spec, prefix):
+        make("depend")
+        make()


### PR DESCRIPTION
Disabled pdf variant and it's dependency because it's causing openssh to never concretize
Comment depends_on("ghostscript", when="+pdf") and variant("pdf", default=False, description="Build the `gropdf` executable.")