### PR TITLE
Debug env python for cf dna analysis 5 20260526 1514

### DIFF
--- a/packages/py-babel/package.py
+++ b/packages/py-babel/package.py
@@ -27,9 +27,11 @@ class PyBabel(PythonPackage):
     version("2.4.0", sha256="8c98f5e5f8f5f088571f2c6bd88d530e331cbbcb95a7311a0db69d3dca7ec563")
     version("2.3.4", sha256="c535c4403802f6eb38173cd4863e419e2274921a01a8aad8a5b497c131c62875")
 
-    depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-pytz@2015.7:", when="@2.12: ^python@:3.8", type=("build", "run"))
-    depends_on("py-pytz@2015.7:", when="@:2.10", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.8:", when="@2.14:")
+        depends_on("py-setuptools")
+        depends_on("py-pytz@2015.7:", when="@2.12: ^python@:3.8")
+        depends_on("py-pytz@2015.7:", when="@:2.10")
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/B/Babel/{}-{}.tar.gz"

--- a/packages/py-babel/package.py
+++ b/packages/py-babel/package.py
@@ -17,6 +17,8 @@ class PyBabel(PythonPackage):
 
     license("BSD-3-Clause")
 
+    import_modules = ["babel"]
+
     version("2.17.0", sha256="0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d")
     version("2.15.0", sha256="8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413")
     version("2.12.1", sha256="cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455")
@@ -39,3 +41,8 @@ class PyBabel(PythonPackage):
         if version >= Version("2.15"):
             name = name.lower()
         return url.format(name, version)
+
+    @run_after("install")
+    def install_test(self):
+        with working_dir("spack-test", create=True):
+            python("-c", "import babel")

--- a/packages/py-gevent/package.py
+++ b/packages/py-gevent/package.py
@@ -23,7 +23,7 @@ class PyGevent(PythonPackage):
     with default_args(type=("build")):
         depends_on("py-setuptools@40.8:69")
         depends_on("py-cython@3:", when="@20.5.1:")
-        depends_on("py-cython@0.29.14:", when="@1.5:")
+        depends_on("py-cython@0.29.14:2", when="@1.5:20.5.0")
 
     with default_args(type=("build", "run")):
         depends_on("python@3.8:", when="@23.7.0:")

--- a/packages/py-gevent/package.py
+++ b/packages/py-gevent/package.py
@@ -23,7 +23,7 @@ class PyGevent(PythonPackage):
     with default_args(type=("build")):
         depends_on("py-setuptools@40.8:69")
         depends_on("py-cython@3:", when="@20.5.1:")
-        depends_on("py-cython@0.29.14:2", when="@1.5:20.5.0")
+        depends_on("py-cython@0.29.14:", when="@1.5:")
 
     with default_args(type=("build", "run")):
         depends_on("python@3.8:", when="@23.7.0:")

--- a/packages/py-gevent/package.py
+++ b/packages/py-gevent/package.py
@@ -34,6 +34,7 @@ class PyGevent(PythonPackage):
         depends_on("py-greenlet@2:", when="@22.10.2: ^python@:3.11")
         depends_on("py-greenlet@1.1:1", when="@21.8:21.12.0")
         depends_on("py-greenlet@0.4.17:1", when="@20.12:21.1.2")
+        depends_on("py-greenlet@0.4.14:0", when="@1.5.0")
         depends_on("py-greenlet@0.4.14:")
         depends_on("py-zope-event", when="@20.5.1:")
         depends_on("py-zope-interface", when="@20.5.1:")

--- a/packages/py-greenlet/package.py
+++ b/packages/py-greenlet/package.py
@@ -29,3 +29,5 @@ class PyGreenlet(PythonPackage):
 
     # PyThreadState.use_tracing was removed in Python 3.10; requires greenlet 1.0+
     conflicts("@:0.4", when="^python@3.10:")
+    # Python 3.12 renamed/removed several PyThreadState members; requires greenlet 3.0+
+    conflicts("@:2", when="^python@3.12:")

--- a/packages/py-greenlet/package.py
+++ b/packages/py-greenlet/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGreenlet(PythonPackage):
+    """Lightweight in-process concurrent programming"""
+
+    homepage = "https://github.com/python-greenlet/greenlet"
+    pypi = "greenlet/greenlet-0.4.17.tar.gz"
+
+    version("3.0.0a1", sha256="1bd4ea36f0aeb14ca335e0c9594a5aaefa1ac4e2db7d86ba38f0be96166b3102")
+    version(
+        "2.0.2",
+        sha256="e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0",
+        preferred=True,
+    )
+    version("1.1.3", sha256="bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455")
+    version("1.1.2", sha256="e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a")
+    version("1.1.0", sha256="c87df8ae3f01ffb4483c796fe1b15232ce2b219f0b18126948616224d3f658ee")
+    version("0.4.17", sha256="41d8835c69a78de718e466dd0e6bfd4b46125f21a67c3ff6d76d8d8059868d6b")
+    version("0.4.13", sha256="0fef83d43bf87a5196c91e73cb9772f945a4caaff91242766c5916d1dd1381e4")
+
+    depends_on("python", type=("build", "link", "run"))
+    depends_on("py-setuptools", type="build")
+
+    # PyThreadState.use_tracing was removed in Python 3.10; requires greenlet 1.0+
+    conflicts("@:0.4", when="^python@3.10:")

--- a/packages/py-ipykernel/package.py
+++ b/packages/py-ipykernel/package.py
@@ -14,6 +14,7 @@ class PyIpykernel(PythonPackage):
     version("6.27.1", sha256="7d5d594b6690654b4d299edba5e872dc17bb7396a8d0609c97cb7b8a1c605de6")
     version("6.15.3", sha256="b81d57b0e171670844bf29cdc11562b1010d3da87115c4513e0ee660a8368765")
 
+    depends_on("python@3.8:", type=("build", "run"), when="@6.17.0:")
     depends_on("py-debugpy@1.6.5:", type=("build", "run"))
     depends_on("py-ipython@7.23.1:", type=("build", "run"))
     depends_on("py-comm@0.1.1:", type=("build", "run"))

--- a/packages/py-nbclient/package.py
+++ b/packages/py-nbclient/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyNbclient(PythonPackage):
+    """A client library for executing notebooks.
+
+    Formally nbconvert's ExecutePreprocessor."""
+
+    homepage = "https://jupyter.org/"
+    pypi = "nbclient/nbclient-0.5.0.tar.gz"
+    git = "https://github.com/jupyter/nbclient.git"
+
+    version("0.8.0", sha256="f9b179cd4b2d7bca965f900a2ebf0db4a12ebff2f36a711cb66861e4ae158e55")
+    version("0.7.2", sha256="884a3f4a8c4fc24bb9302f263e0af47d97f0d01fe11ba714171b320c8ac09547")
+    version("0.6.7", sha256="3c5a7fc6bb74be7d31edf2817b44501a65caa99e5e56363bc359649b97cd24b9")
+    version("0.6.6", sha256="0df76a7961d99a681b4796c74a1f2553b9f998851acc01896dce064ad19a9027")
+    version("0.5.13", sha256="40c52c9b5e3c31faecaee69f202b3f53e38d7c1c563de0fadde9d7eda0fdafe8")
+    version("0.5.5", sha256="ed7d18431393750d29a64da432e0b7889274eb5a5056682be5691b1b1dc8f755")
+    version("0.5.0", sha256="8ad52d27ba144fca1402db014857e53c5a864a2f407be66ca9d74c3a56d6591d")
+
+    depends_on("python@3.8:", when="@0.8:", type=("build", "run"))
+    depends_on("python@3.7:", when="@0.5.13:0.7", type=("build", "run"))
+    depends_on("python@3.6.1:", when="@0.5.5:", type=("build", "run"))
+    depends_on("py-setuptools", when="@:0.7.0", type="build")
+    depends_on("py-hatchling@1.10:", when="@0.7.1:", type="build")
+
+    depends_on("py-jupyter-client@6.1.12:", when="@0.7.1:", type=("build", "run"))
+    depends_on("py-jupyter-client@6.1.5:", type=("build", "run"))
+    depends_on("py-jupyter-core@4.12:4,5.1:", when="@0.7.1:", type=("build", "run"))
+    depends_on("py-nbformat@5.1:", when="@0.7.1:", type=("build", "run"))
+    depends_on("py-nbformat@5.0:", type=("build", "run"))
+    depends_on("py-traitlets@5.4:", when="@0.8:", type=("build", "run"))
+    depends_on("py-traitlets@5.3:", when="@0.7.1:", type=("build", "run"))
+    depends_on("py-traitlets@5.2.2:", when="@0.6:", type=("build", "run"))
+    depends_on("py-traitlets@5:", when="@0.5.13:", type=("build", "run"))
+    depends_on("py-traitlets@4.2:", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-async-generator", when="@0.5.0", type=("build", "run"))
+    depends_on("py-nest-asyncio", when="@:0.7.0", type=("build", "run"))

--- a/packages/py-nbclient/package.py
+++ b/packages/py-nbclient/package.py
@@ -16,6 +16,8 @@ class PyNbclient(PythonPackage):
     pypi = "nbclient/nbclient-0.5.0.tar.gz"
     git = "https://github.com/jupyter/nbclient.git"
 
+    import_modules = ["nbclient"]
+
     version("0.8.0", sha256="f9b179cd4b2d7bca965f900a2ebf0db4a12ebff2f36a711cb66861e4ae158e55")
     version("0.7.2", sha256="884a3f4a8c4fc24bb9302f263e0af47d97f0d01fe11ba714171b320c8ac09547")
     version("0.6.7", sha256="3c5a7fc6bb74be7d31edf2817b44501a65caa99e5e56363bc359649b97cd24b9")
@@ -44,3 +46,8 @@ class PyNbclient(PythonPackage):
     # Historical dependencies
     depends_on("py-async-generator", when="@0.5.0", type=("build", "run"))
     depends_on("py-nest-asyncio", when="@:0.7.0", type=("build", "run"))
+
+    @run_after("install")
+    def install_test(self):
+        with working_dir("spack-test", create=True):
+            python("-c", "import nbclient")

--- a/packages/py-pickle5/package.py
+++ b/packages/py-pickle5/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPickle5(PythonPackage):
+    """This package backports all features and APIs added in the pickle module
+    in Python 3.8.3, including the PEP 574 additions. It should work with Python
+    3.5, 3.6 and 3.7."""
+
+    homepage = "https://github.com/pitrou/pickle5-backport"
+    pypi = "pickle5/pickle5-0.0.11.tar.gz"
+
+    import_modules = ["pickle5"]
+
+    version("0.0.11", sha256="7e013be68ba7dde1de5a8dbcc241f201dab1126e326715916ce4a26c27919ffc")
+
+    depends_on("python@3.5:3.7", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    @run_after("install")
+    def install_test(self):
+        with working_dir("spack-test", create=True):
+            python("-c", "import pickle5")
+

--- a/packages/py-pygments/package.py
+++ b/packages/py-pygments/package.py
@@ -31,6 +31,7 @@ class PyPygments(PythonPackage):
     version("2.0.1", sha256="5e039e1d40d232981ed58914b6d1ac2e453a7e83ddea22ef9f3eeadd01de45cb")
     version("2.0.2", sha256="7320919084e6dac8f4540638a46447a3bd730fca172afc17d2c03eed22cf4f51")
 
+    depends_on("python@3.8:", when="@2.17:")
     depends_on("py-hatchling", when="@2.17:", type="build")
     depends_on("py-setuptools@61:", when="@2.15:2.16", type=("build", "run"))
     depends_on("py-setuptools", when="@:2.14", type=("build", "run"))

--- a/packages/py-pyyaml/package.py
+++ b/packages/py-pyyaml/package.py
@@ -38,6 +38,7 @@ class PyPyyaml(PythonPackage):
 
     depends_on("python@2.7,3.5:", type=("build", "link", "run"))
     depends_on("python@3.6:", when="@6:", type=("build", "link", "run"))
+    depends_on("python@3.8:", when="@6.0.3:", type=("build", "link", "run"))
     depends_on("libyaml", when="+libyaml", type="link")
     # setuptools versions are not documented upstream, the when= constraint
     # should probably be set to a lower version.


### PR DESCRIPTION
- PyPickle5 only works with python@3.5:3.7
- Fix recipes to work with python@3.7 
- New recipes are added from the builtin repo to define a python@3.7 constraint