### PR TITLE
Dependencies for ScanNet environment

### DIFF
--- a/packages/bazel/bazelruleclassprovider-0.24.patch
+++ b/packages/bazel/bazelruleclassprovider-0.24.patch
@@ -1,0 +1,16 @@
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+@@ -172,6 +172,13 @@ public class BazelRuleClassProvider {
+       env.put("PATH", null);
+     }
+ 
++    Map<String, String> spackEnv = System.getenv();
++    for (String envName : spackEnv.keySet()) {
++      if (envName.startsWith("SPACK_")) {
++        env.put(envName, spackEnv.get(envName));
++      }
++    }
++
+     // Shell environment variables specified via options take precedence over the
+     // ones inherited from the fragments. In the long run, these fragments will
+     // be replaced by appropriate default rc files anyway.

--- a/packages/bazel/package.py
+++ b/packages/bazel/package.py
@@ -212,6 +212,10 @@ class Bazel(Package):
         "2.0.0",
         sha256="724da3c656f68e787a86ebb9844773aa1c2e3a873cc39462a8f1b336153d6cbb",
     )
+    version(
+        "0.25.2",
+        sha256="7456032199852c043e6c5b3e4c71dd8089c1158f72ec554e6ec1c77007f0ab51",
+    )
 
     variant(
         "nodepfail",
@@ -235,7 +239,7 @@ class Bazel(Package):
     patch("unix_cc_configure-0.15.patch", when="@:2")
 
     # Set CC and CXX
-    patch("compile-0.29.patch")
+    patch("compile-0.29.patch", when="@2:")
 
     # Disable dependency search
     patch("cppcompileaction-7.0.0.patch", when="@7: +nodepfail")
@@ -316,6 +320,12 @@ class Bazel(Package):
         match = re.search(r"Build label: ([\d.]+)", output)
         return match.group(1) if match else None
 
+    def patch(self):
+        if self.spec.satisfies('@0.25.2'):
+            file = 'third_party/grpc/src/core/lib/gpr/log_linux.cc'
+            filter_file('static long gettid(void)', 'static long gpr_gettid(void)', file, string=True)
+            filter_file('return gettid()', 'return gpr_gettid()', file, string=True)
+
     def setup_build_environment(self, env):
         # fix the broken linking (on power9)
         # https://github.com/bazelbuild/bazel/issues/10327
@@ -339,6 +349,9 @@ class Bazel(Package):
                 continue
 
         env.set("EXTRA_BAZEL_ARGS", args)
+
+        if self.spec.satisfies('@0.25.2'):
+            env.append_flags('CXXFLAGS', '-include limits')
 
     @run_before("install")
     def bootstrap(self):

--- a/packages/bazel/package.py
+++ b/packages/bazel/package.py
@@ -216,6 +216,10 @@ class Bazel(Package):
         "0.25.2",
         sha256="7456032199852c043e6c5b3e4c71dd8089c1158f72ec554e6ec1c77007f0ab51",
     )
+    version(
+        "0.24.1",
+        sha256="56ea1b199003ad832813621744178e42b39e6206d34fbae342562c287da0cd54",
+    )
 
     variant(
         "nodepfail",
@@ -232,7 +236,8 @@ class Bazel(Package):
     depends_on("zip", when="platform=linux", type=("build", "run"))
 
     # Pass Spack environment variables to the build
-    patch("bazelruleclassprovider-0.25.patch")
+    patch("bazelruleclassprovider-0.25.patch", when="@0.25:")
+    patch("bazelruleclassprovider-0.24.patch", when="@0.24")
 
     # Inject include paths
     patch("unix_cc_configure-3.0.patch", when="@3:")
@@ -260,7 +265,7 @@ class Bazel(Package):
     patch("unix_cc_configure_fj-5.2.patch", when="@5.2:%fj")
     patch("unix_cc_configure_fj-5.0.patch", when="@5.0:5.1%fj")
     patch("unix_cc_configure_fj-0.29.1.patch", when="@:4%fj")
-    patch("bazelruleclassprovider_fj-0.25.patch", when="%fj")
+    patch("bazelruleclassprovider_fj-0.25.patch", when="@0.25: %fj")
 
     # https://blog.bazel.build/2021/05/21/bazel-4-1.html
     conflicts("platform=darwin target=aarch64:", when="@:4.0")
@@ -321,10 +326,15 @@ class Bazel(Package):
         return match.group(1) if match else None
 
     def patch(self):
-        if self.spec.satisfies('@0.25.2'):
-            file = 'third_party/grpc/src/core/lib/gpr/log_linux.cc'
-            filter_file('static long gettid(void)', 'static long gpr_gettid(void)', file, string=True)
-            filter_file('return gettid()', 'return gpr_gettid()', file, string=True)
+        if self.spec.satisfies("@:0.25.2"):
+            file = "third_party/grpc/src/core/lib/gpr/log_linux.cc"
+            filter_file("static long gettid(void)", "static long gpr_gettid(void)", file, string=True)
+            filter_file("return gettid()", "return gpr_gettid()", file, string=True)
+
+        if self.spec.satisfies("@0.24.1"):
+            file = "tools/jdk/DumpPlatformClassPath.java"
+            filter_file("import java.util.stream.Stream;", "import java.util.stream.Stream;\nimport java.util.stream.Collectors;", file, string=True)
+            filter_file("""try (Stream<Path> stream = Files.walk(fs.getPath\("/"))) {""", """try (Stream<Path> dynamicStream = Files.walk(fs.getPath("/"))) {""", file, string=True)
 
     def setup_build_environment(self, env):
         # fix the broken linking (on power9)
@@ -338,6 +348,10 @@ class Bazel(Package):
             self.spec["java"].prefix, make_jobs
         )
 
+        if self.spec.satisfies('@0.24.1'):
+            args += " --host_javabase=@bazel_tools//tools/jdk:absolute_javabase"
+            args += " --javabase=@bazel_tools//tools/jdk:absolute_javabase"
+
         resource_stages = self.stage[1:]
         for _resource in resource_stages:
             try:
@@ -350,7 +364,7 @@ class Bazel(Package):
 
         env.set("EXTRA_BAZEL_ARGS", args)
 
-        if self.spec.satisfies('@0.25.2'):
+        if self.spec.satisfies('@:0.25.2'):
             env.append_flags('CXXFLAGS', '-include limits')
 
     @run_before("install")

--- a/packages/py-numba/package.py
+++ b/packages/py-numba/package.py
@@ -31,6 +31,7 @@ class PyNumba(PythonPackage):
     version("0.55.2", sha256="e428d9e11d9ba592849ccc9f7a009003eb7d30612007e365afe743ce7118c6f4")
     version("0.55.1", sha256="03e9069a2666d1c84f93b00dbd716fb8fedde8bb2c6efafa2f04842a46442ea3")
     version("0.54.0", sha256="bad6bd98ab2e41c34aa9c80b8d9737e07d92a53df4f74d3ada1458b0b516ccff")
+    version("0.52.0", sha256="44661c5bd85e3d3619be0a40eedee34e397e9ccb3d4c458b70e10bf95d1ce933")
     version("0.51.1", sha256="1e765b1a41535684bf3b0465c1d0a24dcbbff6af325270c8f4dad924c0940160")
     version("0.50.1", sha256="89e81b51b880f9b18c82b7095beaccc6856fcf84ba29c4f0ced42e4e5748a3a7")
     version("0.48.0", sha256="9d21bc77e67006b5723052840c88cc59248e079a907cc68f1a1a264e1eaba017")

--- a/packages/py-tensorflow/package.py
+++ b/packages/py-tensorflow/package.py
@@ -284,7 +284,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     )
     version(
         "1.14.0",
-        sha256="aa2a6a1daafa3af66807cfe0bc77bfe1144a9a53df9a96bab52e3e575b3047ed",
+        sha256="d982a6fef251ec1358129213385ec027f87ee72246dffe1136ca6109def209f7",
+        url="https://files.pythonhosted.org/packages/f4/28/96efba1a516cdacc2e2d6d081f699c001d414cc8ca3250e6d59ae657eb2b/tensorflow-1.14.0-cp37-cp37m-manylinux1_x86_64.whl",
+        expand=False
     )
 
     # depends_on("c", type="build")  # generated
@@ -351,7 +353,6 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("bazel@3.7.2:3.99.0", when="@2.5:2.6")
         depends_on("bazel@3.1.0:3.99.0", when="@2.3:2.4")
         depends_on("bazel@2.0.0", when="@2.2")
-        depends_on("bazel@0.25.2", when="@1.14")
 
         # tensorflow/tools/pip_package/build_pip_package.sh
         depends_on("patchelf", when="@2.13: platform=linux")
@@ -370,6 +371,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("python@:3.10", when="@2.8:2.11")
         depends_on("python@:3.9", when="@2.5:2.7")
         depends_on("python@:3.8", when="@2.2:2.4")
+        depends_on("python@3.7", when="@1.14.0")
 
         # Listed under REQUIRED_PACKAGES in tensorflow/tools/pip_package/setup.py
         depends_on("py-absl-py@1:", when="@2.9:")
@@ -447,6 +449,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-wrapt@1.11:1.14", when="@2.12,2.14:2.15")
         depends_on("py-wrapt@1.12.1:1.12", when="@2.4:2.6")
         depends_on("py-wrapt@1.11.1:", when="@:2.3")
+        depends_on("py-astor", when="@1.14.0")
+        depends_on("py-keras-applications", when="@1.14.0")
+        depends_on("py-keras-preprocessing", when="@1.14.0")
 
         # TODO: add packages for these dependencies
         # depends_on('py-tensorflow-io-gcs-filesystem@0.23.1:', when='@2.8:')
@@ -606,7 +611,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     )
 
     # needed for protobuf 3.16+
-    patch("example_parsing.patch", when="@:2.7 ^protobuf@3.16:")
+    patch("example_parsing.patch", when="@2.0.0:2.7 ^protobuf@3.16:")
 
     # allow linker to be found in PATH
     # https://github.com/tensorflow/tensorflow/issues/39263
@@ -647,16 +652,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     )
     phases = ["configure", "build", "install"]
 
-    @when("@1.14.0")
-    def patch(self):
-    	filter_file("""define_values = {"tf_api_version": "2"}""", """define_values = {"tf_api_version": "1"}""", "tensorflow/BUILD", string=True)
-    	filter_file("http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz", "https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.1.4.tar.gz", "tensorflow/workspace.bzl", string=True)
-    	filter_file(""""#undef HAVE_SYS_SYSCTL_H": "#define HAVE_SYS_SYSCTL_H 1",""", """"#undef HAVE_SYS_SYSCTL_H": "#undef HAVE_SYS_SYSCTL_H",""", "third_party/hwloc/BUILD.bazel", string=True)
-
-    	with open('.bazelrc', 'a') as f:
-    	    f.write("\nbuild --copt=-std=c++14\nbuild --per_file_copt=external/com_google_absl/.*@-include,limits\n")
-
     # https://www.tensorflow.org/install/source
+    @when("@1.15:")
     def setup_build_environment(self, env):
         spec = self.spec
 
@@ -911,6 +908,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         env.set("TEST_TMPDIR", tmp_path)
 
     def configure(self, spec, prefix):
+        if spec.satisfies("@1.14.0"):
+            return
         # NOTE: configure script is interactive. If you set the appropriate
         # environment variables, this interactivity is skipped. If you don't,
         # Spack hangs during the configure phase. Use `spack build-env` to
@@ -921,6 +920,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     @run_after("configure")
     def post_configure_fixes(self):
         spec = self.spec
+
+        if spec.satisfies("@1.14.0"):
+            return
 
         if spec.satisfies("@2.17:"):
             filter_file(
@@ -1037,6 +1039,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                         f.truncate()
 
     def build(self, spec, prefix):
+        if spec.satisfies("@1.14.0"):
+            return
+
         # Bazel needs the directory to exist on install
         mkdirp(python_platlib)
         tmp_path = env["TEST_TMPDIR"]
@@ -1215,6 +1220,13 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
             build_pip_package("--src", buildpath)
 
     def install(self, spec, prefix):
+        if spec.satisfies("@1.14,9"):
+            args = std_pip_args + ["--prefix=", self.stage.archive_file]
+
+            pip(*args)
+
+            return
+
         tmp_path = env["TEST_TMPDIR"]
         if self.spec.satisfies("@2.17:"):
             buildpath = join_path(
@@ -1232,3 +1244,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                 pip(*args)
 
         remove_linked_tree(tmp_path)
+
+    @run_after("install")
+    def install_test(self):
+        python("-c", "import tensorflow")

--- a/packages/py-tensorflow/package.py
+++ b/packages/py-tensorflow/package.py
@@ -282,6 +282,10 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         "2.2.0",
         sha256="69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3",
     )
+    version(
+        "1.14.0",
+        sha256="aa2a6a1daafa3af66807cfe0bc77bfe1144a9a53df9a96bab52e3e575b3047ed",
+    )
 
     # depends_on("c", type="build")  # generated
     # depends_on("cxx", type="build")  # generated
@@ -347,6 +351,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("bazel@3.7.2:3.99.0", when="@2.5:2.6")
         depends_on("bazel@3.1.0:3.99.0", when="@2.3:2.4")
         depends_on("bazel@2.0.0", when="@2.2")
+        depends_on("bazel@0.25.2", when="@1.14")
 
         # tensorflow/tools/pip_package/build_pip_package.sh
         depends_on("patchelf", when="@2.13: platform=linux")
@@ -416,7 +421,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         depends_on("py-numpy@1.14.5:", when="@2.7")
         depends_on("py-numpy@1.19.2:1.19", when="@2.4:2.6")
         # https://github.com/tensorflow/tensorflow/issues/40688
-        depends_on("py-numpy@1.16.0:1.18", when="@:2.3")
+        depends_on("py-numpy@1.16.0:1.18", when="@2:2.3")
         # https://github.com/tensorflow/tensorflow/issues/67291
         depends_on("py-numpy@:1")
         depends_on("py-opt-einsum@2.3.2:", when="@:2.3,2.7:")
@@ -641,6 +646,15 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         when="@2.16.1-rocm-enhanced +rocm",
     )
     phases = ["configure", "build", "install"]
+
+    @when("@1.14.0")
+    def patch(self):
+    	filter_file("""define_values = {"tf_api_version": "2"}""", """define_values = {"tf_api_version": "1"}""", "tensorflow/BUILD", string=True)
+    	filter_file("http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz", "https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.1.4.tar.gz", "tensorflow/workspace.bzl", string=True)
+    	filter_file(""""#undef HAVE_SYS_SYSCTL_H": "#define HAVE_SYS_SYSCTL_H 1",""", """"#undef HAVE_SYS_SYSCTL_H": "#undef HAVE_SYS_SYSCTL_H",""", "third_party/hwloc/BUILD.bazel", string=True)
+
+    	with open('.bazelrc', 'a') as f:
+    	    f.write("\nbuild --copt=-std=c++14\nbuild --per_file_copt=external/com_google_absl/.*@-include,limits\n")
 
     # https://www.tensorflow.org/install/source
     def setup_build_environment(self, env):
@@ -1190,6 +1204,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
                         f.write(content)
                         f.truncate()
 
+        bazel = Executable(self.spec["bazel"].command.path)
         bazel(*args)
 
         if self.spec.satisfies("@:2.16"):


### PR DESCRIPTION
The Bazel update isn't strictly required, it was part of a failed attempt to compile py-tensorflow@1.14.0 from source, but it works.